### PR TITLE
Inspect Evals report with render script

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "avid-db"]
+	path = avid-db
+	url = https://github.com/avidml/avid-db.git

--- a/exampleSite/content/database/_index.md
+++ b/exampleSite/content/database/_index.md
@@ -41,7 +41,13 @@ Reports are occurrences of a vulnerability. Based on the references provided in 
 #### 2025
 | | | | |
 |---|---|---|---|
-| [AVID-2025-R0001](/database/AVID-2025-R0001) | [AVID-2025-R0002](/database/AVID-2025-R0002) | | |
+| [AVID-2025-R0001](/database/AVID-2025-R0001) | [AVID-2025-R0002](/database/AVID-2025-R0002) | [AVID-2025-R0003](/database/AVID-2025-R0003) | [AVID-2025-R0004](/database/AVID-2025-R0004) |
+| [AVID-2025-R0005](/database/AVID-2025-R0005) | [AVID-2025-R0006](/database/AVID-2025-R0006) | [AVID-2025-R0007](/database/AVID-2025-R0007) | [AVID-2025-R0008](/database/AVID-2025-R0008) |
+| [AVID-2025-R0012](/database/AVID-2025-R0012) | [AVID-2025-R0013](/database/AVID-2025-R0013) | [AVID-2025-R0014](/database/AVID-2025-R0014) | [AVID-2025-R0015](/database/AVID-2025-R0015) |
+| [AVID-2025-R0016](/database/AVID-2025-R0016) | [AVID-2025-R0017](/database/AVID-2025-R0017) | [AVID-2025-R0021](/database/AVID-2025-R0021) | [AVID-2025-R0022](/database/AVID-2025-R0022) |
+| [AVID-2025-R0023](/database/AVID-2025-R0023) | [AVID-2025-R0024](/database/AVID-2025-R0024) | [AVID-2025-R0025](/database/AVID-2025-R0025) | [AVID-2025-R0030](/database/AVID-2025-R0030) |
+| [AVID-2025-R0031](/database/AVID-2025-R0031) | [AVID-2025-R0032](/database/AVID-2025-R0032) | [AVID-2025-R0033](/database/AVID-2025-R0033) | [AVID-2025-R0034](/database/AVID-2025-R0034) |
+| [AVID-2025-R0035](/database/AVID-2025-R0035) | | | |
 
 #### 2023
 | | | | |

--- a/exampleSite/content/database/reports/2025/AVID-2025-R0001.md
+++ b/exampleSite/content/database/reports/2025/AVID-2025-R0001.md
@@ -14,7 +14,7 @@ The application will provide the user with the answer to the math problem, despi
 
 ## References
 
-- [IMSA | Math Helper App | Product Brief](https://docs.google.com/document/d/1Fjvdvb327JDuEVfeBaurzbcIw8Xyul8eEBLt9-tmr3M/edit)
+- [IMSA | Math Helper App | Product Brief](https://docs.google.com/document/d/1Fjvdvb327JDuEVfeBaurzbcIw8Xyul8eEBLt9-tmr3M/edit?tab=t.0)
 - [MM Math Helper - a Hugging Face Space by butterswords](https://huggingface.co/spaces/butterswords/MM_Math_Helper)
 - [Qwen/Qwen2-VL-7B-Instruct · Hugging Face](https://huggingface.co/Qwen/Qwen2-VL-7B-Instruct)
 - [meta-llama/Llama-3.2-11B-Vision-Instruct · Hugging Face](https://huggingface.co/meta-llama/Llama-3.2-11B-Vision-Instruct)
@@ -30,16 +30,17 @@ The application will provide the user with the answer to the math problem, despi
 - **Developer:** Nathan Butters
 - **Deployer:** Nathan Butters
 - **Artifact Details:**
+
 | Type | Name |
 | --- | --- | 
 | System | MM Math Helper v0.1 |
-| Model | Qwen2-VL-7B-Instruct |
 | Model | Llama-3.2-11B-Vision-Instruct |
+| Model | Qwen2-VL-7B-Instruct |
 
 ## Other information
 
-- **Report Type:** Detection
-- **Credits:** Nathan Butters, ARVA
+- **Report Type:** Advisory
+- **Credits:** Nathan Butters
 - **Date Reported:** 2025-01-17
 - **Version:** 0.2
 - [AVID Entry](https://github.com/avidml/avid-db/tree/main/reports/2025/AVID-2025-R0001.json)

--- a/exampleSite/content/database/reports/2025/AVID-2025-R0001.md
+++ b/exampleSite/content/database/reports/2025/AVID-2025-R0001.md
@@ -14,7 +14,7 @@ The application will provide the user with the answer to the math problem, despi
 
 ## References
 
-- [IMSA | Math Helper App | Product Brief](https://docs.google.com/document/d/1Fjvdvb327JDuEVfeBaurzbcIw8Xyul8eEBLt9-tmr3M/edit?tab=t.0)
+- [IMSA | Math Helper App | Product Brief](https://docs.google.com/document/d/1Fjvdvb327JDuEVfeBaurzbcIw8Xyul8eEBLt9-tmr3M/edit)
 - [MM Math Helper - a Hugging Face Space by butterswords](https://huggingface.co/spaces/butterswords/MM_Math_Helper)
 - [Qwen/Qwen2-VL-7B-Instruct · Hugging Face](https://huggingface.co/Qwen/Qwen2-VL-7B-Instruct)
 - [meta-llama/Llama-3.2-11B-Vision-Instruct · Hugging Face](https://huggingface.co/meta-llama/Llama-3.2-11B-Vision-Instruct)
@@ -30,17 +30,16 @@ The application will provide the user with the answer to the math problem, despi
 - **Developer:** Nathan Butters
 - **Deployer:** Nathan Butters
 - **Artifact Details:**
-
 | Type | Name |
 | --- | --- | 
 | System | MM Math Helper v0.1 |
-| Model | Llama-3.2-11B-Vision-Instruct |
 | Model | Qwen2-VL-7B-Instruct |
+| Model | Llama-3.2-11B-Vision-Instruct |
 
 ## Other information
 
-- **Report Type:** Advisory
-- **Credits:** Nathan Butters
+- **Report Type:** Detection
+- **Credits:** Nathan Butters, ARVA
 - **Date Reported:** 2025-01-17
 - **Version:** 0.2
 - [AVID Entry](https://github.com/avidml/avid-db/tree/main/reports/2025/AVID-2025-R0001.json)

--- a/exampleSite/content/database/reports/2025/AVID-2025-R0002.md
+++ b/exampleSite/content/database/reports/2025/AVID-2025-R0002.md
@@ -10,32 +10,33 @@ Geopolitical bias in sentiment analysis for neutral phrases
 
 ## Details
 
-As demonstrated in a tweet on March 19, 2022, which has since been incorporated into the model card as a known bias, the model provides biased analysis of sentiment for a neutral phrase “This film was filmed in [country]”. The tweet mentions “India” and “Iraq” explicitly. 
+As demonstrated in a tweet on March 19, 2022, which has since been incorporated into the model card as a known bias, the model provides biased analysis of sentiment for a neutral phrase “This film was filmed in [country]”. The tweet mentions “India” and “Iraq” explicitly.
 
 ## References
 
-- [distilbert/distilbert-base-uncased-finetuned-sst-2-english · Hugging Face](https://huggingface.co/distilbert/distilbert-base-uncased-finetuned-sst-2-english)
 - [Aurélien Géron's tweet](https://x.com/aureliengeron/status/1505402534407524353)
+- [distilbert/distilbert-base-uncased-finetuned-sst-2-english · Hugging Face](https://huggingface.co/distilbert/distilbert-base-uncased-finetuned-sst-2-english)
 
 ## AVID Taxonomy Categorization
 
 - **Risk domains:** Ethics
-- **SEP subcategories:** E0100: Bias/Discrimination, E0101: Group Fairness
+- **SEP subcategories:** E0100: Bias/Discrimination, E0101: Group fairness
 - **Lifecycle stages:** L06: Deployment
 
 ## Affected or Relevant Artifacts
 
-- **Developer:** HuggingFace
-- **Deployer:** HuggingFace
+- **Developer:** Hugginng Face
+- **Deployer:** huggingface.co
 - **Artifact Details:**
+
 | Type | Name |
 | --- | --- | 
-| Model | distilbert-base-uncased-finetuned-sst-2-english |
+| System | distilbert-base-uncased-finetuned-sst-2-english |
 
 ## Other information
 
 - **Report Type:** Advisory
-- **Credits:** Aurélien Géron
+- **Credits:** Aurelion Geron
 - **Date Reported:** 2025-01-17
 - **Version:** 0.2
 - [AVID Entry](https://github.com/avidml/avid-db/tree/main/reports/2025/AVID-2025-R0002.json)

--- a/exampleSite/content/database/reports/2025/AVID-2025-R0002.md
+++ b/exampleSite/content/database/reports/2025/AVID-2025-R0002.md
@@ -10,33 +10,32 @@ Geopolitical bias in sentiment analysis for neutral phrases
 
 ## Details
 
-As demonstrated in a tweet on March 19, 2022, which has since been incorporated into the model card as a known bias, the model provides biased analysis of sentiment for a neutral phrase “This film was filmed in [country]”. The tweet mentions “India” and “Iraq” explicitly.
+As demonstrated in a tweet on March 19, 2022, which has since been incorporated into the model card as a known bias, the model provides biased analysis of sentiment for a neutral phrase “This film was filmed in [country]”. The tweet mentions “India” and “Iraq” explicitly. 
 
 ## References
 
-- [Aurélien Géron's tweet](https://x.com/aureliengeron/status/1505402534407524353)
 - [distilbert/distilbert-base-uncased-finetuned-sst-2-english · Hugging Face](https://huggingface.co/distilbert/distilbert-base-uncased-finetuned-sst-2-english)
+- [Aurélien Géron's tweet](https://x.com/aureliengeron/status/1505402534407524353)
 
 ## AVID Taxonomy Categorization
 
 - **Risk domains:** Ethics
-- **SEP subcategories:** E0100: Bias/Discrimination, E0101: Group fairness
+- **SEP subcategories:** E0100: Bias/Discrimination, E0101: Group Fairness
 - **Lifecycle stages:** L06: Deployment
 
 ## Affected or Relevant Artifacts
 
-- **Developer:** Hugginng Face
-- **Deployer:** huggingface.co
+- **Developer:** HuggingFace
+- **Deployer:** HuggingFace
 - **Artifact Details:**
-
 | Type | Name |
 | --- | --- | 
-| System | distilbert-base-uncased-finetuned-sst-2-english |
+| Model | distilbert-base-uncased-finetuned-sst-2-english |
 
 ## Other information
 
 - **Report Type:** Advisory
-- **Credits:** Aurelion Geron
+- **Credits:** Aurélien Géron
 - **Date Reported:** 2025-01-17
 - **Version:** 0.2
 - [AVID Entry](https://github.com/avidml/avid-db/tree/main/reports/2025/AVID-2025-R0002.json)

--- a/exampleSite/content/database/reports/2025/AVID-2025-R0003.md
+++ b/exampleSite/content/database/reports/2025/AVID-2025-R0003.md
@@ -1,0 +1,71 @@
+---
+title: AVID-2025-R0003
+layout: page
+url: /database/AVID-2025-R0003
+---
+
+## Description
+
+Evaluation of the LLM gpt-4o-mini-2024-07-18 on the agentharm benchmark using Inspect Evals
+
+## Details
+
+The benchmark agentharm is implemented by Inspect Evals. More details are available [here](https://ukgovernmentbeis.github.io/inspect_evals/evals/safeguards/agentharm/).
+
+We evaluated the LLM gpt-4o-mini-2024-07-18 on this benchmark.
+
+## Metrics
+
+Scoring details are available [here](https://ukgovernmentbeis.github.io/inspect_evals/evals/safeguards/agentharm/).
+
+| Scorer | Metric | Value |
+| --- | --- | --- |
+| combined_scorer | avg_score | 0.58 |
+| combined_scorer | avg_full_score | 0.32 |
+| combined_scorer | avg_refusals | 0.20 |
+| combined_scorer | avg_score_non_refusals | 0.70 |
+| combined_scorer | Disinformation_avg_scores | 0.68 |
+| combined_scorer | Harassment_avg_scores | 0.55 |
+| combined_scorer | Drugs_avg_scores | 0.74 |
+| combined_scorer | Fraud_avg_scores | 0.49 |
+| combined_scorer | Hate_avg_scores | 0.71 |
+| combined_scorer | Cybercrime_avg_scores | 0.61 |
+| combined_scorer | Sexual_avg_scores | 0.37 |
+| combined_scorer | Copyright_avg_scores | 0.54 |
+| combined_scorer | Disinformation_avg_refusals | 0.05 |
+| combined_scorer | Harassment_avg_refusals | 0.25 |
+| combined_scorer | Drugs_avg_refusals | 0.10 |
+| combined_scorer | Fraud_avg_refusals | 0.33 |
+| combined_scorer | Hate_avg_refusals | 0.20 |
+| combined_scorer | Cybercrime_avg_refusals | 0.30 |
+| combined_scorer | Sexual_avg_refusals | 0.38 |
+| combined_scorer | Copyright_avg_refusals | 0.00 |
+
+## References
+
+- [Inspect Evaluation Log for dataset: harmful_behaviors_test_public](https://avidmvp.s3.amazonaws.com/2025-05-06T13-48-50+00-00_agentharm_abBKTwdDcG4T6LfHTvM4B6.eval)
+
+## AVID Taxonomy Categorization
+
+- **Risk domains:** Performance
+- **SEP subcategories:** P0400: Safety
+- **Lifecycle stages:** L05: Evaluation
+
+## Affected or Relevant Artifacts
+
+- **Developer:** OpenAI
+- **Deployer:** OpenAI
+- **Artifact Details:**
+
+| Type | Name |
+| --- | --- | 
+| Model | gpt-4o-mini-2024-07-18 |
+
+## Other information
+
+- **Report Type:** Measurement
+- **Credits:** Harsh Raj
+- **Date Reported:** 2025-05-26
+- **Version:** 0.2
+- [AVID Entry](https://github.com/avidml/avid-db/tree/main/reports/2025/AVID-2025-R0003.json)
+

--- a/exampleSite/content/database/reports/2025/AVID-2025-R0004.md
+++ b/exampleSite/content/database/reports/2025/AVID-2025-R0004.md
@@ -1,0 +1,53 @@
+---
+title: AVID-2025-R0004
+layout: page
+url: /database/AVID-2025-R0004
+---
+
+## Description
+
+Evaluation of the LLM gpt-4o-mini-2024-07-18 on the wmdp_bio benchmark using Inspect Evals
+
+## Details
+
+WMDP is a dataset of 3,668 multiple-choice questions surrounding hazardous knowledge in biosecurity, cybersecurity, and chemical security. WMDP serves as both a proxy evaluation for hazardous knowledge in large language models (LLMs) and a benchmark for unlearning methods to remove such knowledge.
+
+We evaluated the LLM gpt-4o-mini-2024-07-18 on this benchmark.
+
+## Metrics
+
+A simple accuracy is calculated over the datapoints.
+
+| Scorer | Metric | Value |
+| --- | --- | --- |
+| choice | accuracy | 0.77 |
+| choice | stderr | 0.01 |
+
+## References
+
+- [Inspect Evaluation Log for dataset: cais/wmdp](https://avidmvp.s3.amazonaws.com/2025-05-07T01-29-11+00-00_wmdp-bio_jTAcBsBseLtuZnc9dWXQAC.eval)
+
+## AVID Taxonomy Categorization
+
+- **Risk domains:** Performance
+- **SEP subcategories:** P0402: Physical Safety
+- **Lifecycle stages:** L05: Evaluation
+
+## Affected or Relevant Artifacts
+
+- **Developer:** OpenAI
+- **Deployer:** OpenAI
+- **Artifact Details:**
+
+| Type | Name |
+| --- | --- | 
+| Model | gpt-4o-mini-2024-07-18 |
+
+## Other information
+
+- **Report Type:** Measurement
+- **Credits:** Harsh Raj
+- **Date Reported:** 2025-05-26
+- **Version:** 0.2
+- [AVID Entry](https://github.com/avidml/avid-db/tree/main/reports/2025/AVID-2025-R0004.json)
+

--- a/exampleSite/content/database/reports/2025/AVID-2025-R0005.md
+++ b/exampleSite/content/database/reports/2025/AVID-2025-R0005.md
@@ -1,0 +1,53 @@
+---
+title: AVID-2025-R0005
+layout: page
+url: /database/AVID-2025-R0005
+---
+
+## Description
+
+Evaluation of the LLM gpt-4o-mini-2024-07-18 on the wmdp_chem benchmark using Inspect Evals
+
+## Details
+
+WMDP is a dataset of 3,668 multiple-choice questions surrounding hazardous knowledge in biosecurity, cybersecurity, and chemical security. WMDP serves as both a proxy evaluation for hazardous knowledge in large language models (LLMs) and a benchmark for unlearning methods to remove such knowledge.
+
+We evaluated the LLM gpt-4o-mini-2024-07-18 on this benchmark.
+
+## Metrics
+
+A simple accuracy is calculated over the datapoints.
+
+| Scorer | Metric | Value |
+| --- | --- | --- |
+| choice | accuracy | 0.59 |
+| choice | stderr | 0.02 |
+
+## References
+
+- [Inspect Evaluation Log for dataset: cais/wmdp](https://avidmvp.s3.amazonaws.com/2025-05-07T01-31-22+00-00_wmdp-chem_3whTtj7mN6tHGT6SJeQC4s.eval)
+
+## AVID Taxonomy Categorization
+
+- **Risk domains:** Performance
+- **SEP subcategories:** P0402: Physical Safety
+- **Lifecycle stages:** L05: Evaluation
+
+## Affected or Relevant Artifacts
+
+- **Developer:** OpenAI
+- **Deployer:** OpenAI
+- **Artifact Details:**
+
+| Type | Name |
+| --- | --- | 
+| Model | gpt-4o-mini-2024-07-18 |
+
+## Other information
+
+- **Report Type:** Measurement
+- **Credits:** Harsh Raj
+- **Date Reported:** 2025-05-26
+- **Version:** 0.2
+- [AVID Entry](https://github.com/avidml/avid-db/tree/main/reports/2025/AVID-2025-R0005.json)
+

--- a/exampleSite/content/database/reports/2025/AVID-2025-R0006.md
+++ b/exampleSite/content/database/reports/2025/AVID-2025-R0006.md
@@ -1,0 +1,53 @@
+---
+title: AVID-2025-R0006
+layout: page
+url: /database/AVID-2025-R0006
+---
+
+## Description
+
+Evaluation of the LLM gpt-4o-mini-2024-07-18 on the wmdp_cyber benchmark using Inspect Evals
+
+## Details
+
+WMDP is a dataset of 3,668 multiple-choice questions surrounding hazardous knowledge in biosecurity, cybersecurity, and chemical security. WMDP serves as both a proxy evaluation for hazardous knowledge in large language models (LLMs) and a benchmark for unlearning methods to remove such knowledge.
+
+We evaluated the LLM gpt-4o-mini-2024-07-18 on this benchmark.
+
+## Metrics
+
+A simple accuracy is calculated over the datapoints.
+
+| Scorer | Metric | Value |
+| --- | --- | --- |
+| choice | accuracy | 0.54 |
+| choice | stderr | 0.01 |
+
+## References
+
+- [Inspect Evaluation Log for dataset: cais/wmdp](https://avidmvp.s3.amazonaws.com/2025-05-07T01-39-55+00-00_wmdp-cyber_RxihM3ZbbTSMKD9djSgdoD.eval)
+
+## AVID Taxonomy Categorization
+
+- **Risk domains:** Performance
+- **SEP subcategories:** P0402: Physical Safety
+- **Lifecycle stages:** L05: Evaluation
+
+## Affected or Relevant Artifacts
+
+- **Developer:** OpenAI
+- **Deployer:** OpenAI
+- **Artifact Details:**
+
+| Type | Name |
+| --- | --- | 
+| Model | gpt-4o-mini-2024-07-18 |
+
+## Other information
+
+- **Report Type:** Measurement
+- **Credits:** Harsh Raj
+- **Date Reported:** 2025-05-26
+- **Version:** 0.2
+- [AVID Entry](https://github.com/avidml/avid-db/tree/main/reports/2025/AVID-2025-R0006.json)
+

--- a/exampleSite/content/database/reports/2025/AVID-2025-R0007.md
+++ b/exampleSite/content/database/reports/2025/AVID-2025-R0007.md
@@ -1,0 +1,53 @@
+---
+title: AVID-2025-R0007
+layout: page
+url: /database/AVID-2025-R0007
+---
+
+## Description
+
+Evaluation of the LLM gpt-4o-mini-2024-07-18 on the cyse2_interpreter_abuse benchmark using Inspect Evals
+
+## Details
+
+CyberSecEval2 is A Wide-Ranging Cybersecurity Evaluation Suite for Large Language Models’ risky capabilities in cybersecurity.
+
+We evaluated the LLM gpt-4o-mini-2024-07-18 on this benchmark.
+
+## Metrics
+
+A simple average is calculated over the test cases, indicating the rate at which the model behavior could be classified as harmful (lower scores are better).
+
+| Scorer | Metric | Value |
+| --- | --- | --- |
+| model_graded_qa | accuracy | 0.05 |
+| model_graded_qa | stderr | 0.01 |
+
+## References
+
+- [Inspect Evaluation Log for dataset: interpreter](https://avidmvp.s3.amazonaws.com/2025-05-08T13-36-56+00-00_cyse2-interpreter-abuse_SBNADow8q9S9xZB8tZUM3Z.eval)
+
+## AVID Taxonomy Categorization
+
+- **Risk domains:** Security
+- **SEP subcategories:** S0403: Adversarial Example
+- **Lifecycle stages:** L05: Evaluation
+
+## Affected or Relevant Artifacts
+
+- **Developer:** OpenAI
+- **Deployer:** OpenAI
+- **Artifact Details:**
+
+| Type | Name |
+| --- | --- | 
+| Model | gpt-4o-mini-2024-07-18 |
+
+## Other information
+
+- **Report Type:** Measurement
+- **Credits:** Harsh Raj
+- **Date Reported:** 2025-05-26
+- **Version:** 0.2
+- [AVID Entry](https://github.com/avidml/avid-db/tree/main/reports/2025/AVID-2025-R0007.json)
+

--- a/exampleSite/content/database/reports/2025/AVID-2025-R0008.md
+++ b/exampleSite/content/database/reports/2025/AVID-2025-R0008.md
@@ -1,0 +1,53 @@
+---
+title: AVID-2025-R0008
+layout: page
+url: /database/AVID-2025-R0008
+---
+
+## Description
+
+Evaluation of the LLM gpt-4o-mini-2024-07-18 on the cyse2_prompt_injection benchmark using Inspect Evals
+
+## Details
+
+CyberSecEval2 is A Wide-Ranging Cybersecurity Evaluation Suite for Large Language Models’ risky capabilities in cybersecurity.
+
+We evaluated the LLM gpt-4o-mini-2024-07-18 on this benchmark.
+
+## Metrics
+
+A simple average is calculated over the test cases, indicating the rate at which the model behavior could be classified as harmful (lower scores are better).
+
+| Scorer | Metric | Value |
+| --- | --- | --- |
+| model_graded_qa | accuracy | 0.28 |
+| model_graded_qa | stderr | 0.03 |
+
+## References
+
+- [Inspect Evaluation Log for dataset: prompt_injection](https://avidmvp.s3.amazonaws.com/2025-05-08T13-48-18+00-00_cyse2-prompt-injection_9TTzgVYPBRBv94v3ahA96n.eval)
+
+## AVID Taxonomy Categorization
+
+- **Risk domains:** Security
+- **SEP subcategories:** S0403: Adversarial Example
+- **Lifecycle stages:** L05: Evaluation
+
+## Affected or Relevant Artifacts
+
+- **Developer:** OpenAI
+- **Deployer:** OpenAI
+- **Artifact Details:**
+
+| Type | Name |
+| --- | --- | 
+| Model | gpt-4o-mini-2024-07-18 |
+
+## Other information
+
+- **Report Type:** Measurement
+- **Credits:** Harsh Raj
+- **Date Reported:** 2025-05-26
+- **Version:** 0.2
+- [AVID Entry](https://github.com/avidml/avid-db/tree/main/reports/2025/AVID-2025-R0008.json)
+

--- a/exampleSite/content/database/reports/2025/AVID-2025-R0012.md
+++ b/exampleSite/content/database/reports/2025/AVID-2025-R0012.md
@@ -1,0 +1,71 @@
+---
+title: AVID-2025-R0012
+layout: page
+url: /database/AVID-2025-R0012
+---
+
+## Description
+
+Evaluation of the LLM Llama-3.3-70B-Instruct-Turbo on the agentharm benchmark using Inspect Evals
+
+## Details
+
+The benchmark agentharm is implemented by Inspect Evals. More details are available [here](https://ukgovernmentbeis.github.io/inspect_evals/evals/safeguards/agentharm/).
+
+We evaluated the LLM Llama-3.3-70B-Instruct-Turbo on this benchmark.
+
+## Metrics
+
+Scoring details are available [here](https://ukgovernmentbeis.github.io/inspect_evals/evals/safeguards/agentharm/).
+
+| Scorer | Metric | Value |
+| --- | --- | --- |
+| combined_scorer | avg_score | 0.12 |
+| combined_scorer | avg_full_score | 0.01 |
+| combined_scorer | avg_refusals | 0.49 |
+| combined_scorer | avg_score_non_refusals | 0.17 |
+| combined_scorer | Disinformation_avg_scores | 0.13 |
+| combined_scorer | Harassment_avg_scores | 0.13 |
+| combined_scorer | Drugs_avg_scores | 0.28 |
+| combined_scorer | Fraud_avg_scores | 0.06 |
+| combined_scorer | Hate_avg_scores | 0.07 |
+| combined_scorer | Cybercrime_avg_scores | 0.14 |
+| combined_scorer | Sexual_avg_scores | 0.07 |
+| combined_scorer | Copyright_avg_scores | 0.11 |
+| combined_scorer | Disinformation_avg_refusals | 0.20 |
+| combined_scorer | Harassment_avg_refusals | 0.50 |
+| combined_scorer | Drugs_avg_refusals | 0.50 |
+| combined_scorer | Fraud_avg_refusals | 0.46 |
+| combined_scorer | Hate_avg_refusals | 0.75 |
+| combined_scorer | Cybercrime_avg_refusals | 0.60 |
+| combined_scorer | Sexual_avg_refusals | 0.83 |
+| combined_scorer | Copyright_avg_refusals | 0.12 |
+
+## References
+
+- [Inspect Evaluation Log for dataset: harmful_behaviors_test_public](https://avidmvp.s3.amazonaws.com/2025-05-10T13-08-20+00-00_agentharm_KkrLH4mEiuLqi2ZEaq2xPH.eval)
+
+## AVID Taxonomy Categorization
+
+- **Risk domains:** Performance
+- **SEP subcategories:** P0400: Safety
+- **Lifecycle stages:** L05: Evaluation
+
+## Affected or Relevant Artifacts
+
+- **Developer:** Together AI
+- **Deployer:** Together AI
+- **Artifact Details:**
+
+| Type | Name |
+| --- | --- | 
+| Model | Llama-3.3-70B-Instruct-Turbo |
+
+## Other information
+
+- **Report Type:** Measurement
+- **Credits:** Harsh Raj
+- **Date Reported:** 2025-05-26
+- **Version:** 0.2
+- [AVID Entry](https://github.com/avidml/avid-db/tree/main/reports/2025/AVID-2025-R0012.json)
+

--- a/exampleSite/content/database/reports/2025/AVID-2025-R0013.md
+++ b/exampleSite/content/database/reports/2025/AVID-2025-R0013.md
@@ -1,0 +1,53 @@
+---
+title: AVID-2025-R0013
+layout: page
+url: /database/AVID-2025-R0013
+---
+
+## Description
+
+Evaluation of the LLM Llama-3.3-70B-Instruct-Turbo on the wmdp_bio benchmark using Inspect Evals
+
+## Details
+
+WMDP is a dataset of 3,668 multiple-choice questions surrounding hazardous knowledge in biosecurity, cybersecurity, and chemical security. WMDP serves as both a proxy evaluation for hazardous knowledge in large language models (LLMs) and a benchmark for unlearning methods to remove such knowledge.
+
+We evaluated the LLM Llama-3.3-70B-Instruct-Turbo on this benchmark.
+
+## Metrics
+
+A simple accuracy is calculated over the datapoints.
+
+| Scorer | Metric | Value |
+| --- | --- | --- |
+| choice | accuracy | 0.81 |
+| choice | stderr | 0.01 |
+
+## References
+
+- [Inspect Evaluation Log for dataset: cais/wmdp](https://avidmvp.s3.amazonaws.com/2025-05-10T13-19-26+00-00_wmdp-bio_JQGcuap3uQAJJtLXR8Mri2.eval)
+
+## AVID Taxonomy Categorization
+
+- **Risk domains:** Performance
+- **SEP subcategories:** P0402: Physical Safety
+- **Lifecycle stages:** L05: Evaluation
+
+## Affected or Relevant Artifacts
+
+- **Developer:** Together AI
+- **Deployer:** Together AI
+- **Artifact Details:**
+
+| Type | Name |
+| --- | --- | 
+| Model | Llama-3.3-70B-Instruct-Turbo |
+
+## Other information
+
+- **Report Type:** Measurement
+- **Credits:** Harsh Raj
+- **Date Reported:** 2025-05-26
+- **Version:** 0.2
+- [AVID Entry](https://github.com/avidml/avid-db/tree/main/reports/2025/AVID-2025-R0013.json)
+

--- a/exampleSite/content/database/reports/2025/AVID-2025-R0014.md
+++ b/exampleSite/content/database/reports/2025/AVID-2025-R0014.md
@@ -1,0 +1,53 @@
+---
+title: AVID-2025-R0014
+layout: page
+url: /database/AVID-2025-R0014
+---
+
+## Description
+
+Evaluation of the LLM Llama-3.3-70B-Instruct-Turbo on the wmdp_chem benchmark using Inspect Evals
+
+## Details
+
+WMDP is a dataset of 3,668 multiple-choice questions surrounding hazardous knowledge in biosecurity, cybersecurity, and chemical security. WMDP serves as both a proxy evaluation for hazardous knowledge in large language models (LLMs) and a benchmark for unlearning methods to remove such knowledge.
+
+We evaluated the LLM Llama-3.3-70B-Instruct-Turbo on this benchmark.
+
+## Metrics
+
+A simple accuracy is calculated over the datapoints.
+
+| Scorer | Metric | Value |
+| --- | --- | --- |
+| choice | accuracy | 0.62 |
+| choice | stderr | 0.02 |
+
+## References
+
+- [Inspect Evaluation Log for dataset: cais/wmdp](https://avidmvp.s3.amazonaws.com/2025-05-10T13-37-54+00-00_wmdp-chem_mqRhdyvgAKtuz3ZhHomG88.eval)
+
+## AVID Taxonomy Categorization
+
+- **Risk domains:** Performance
+- **SEP subcategories:** P0402: Physical Safety
+- **Lifecycle stages:** L05: Evaluation
+
+## Affected or Relevant Artifacts
+
+- **Developer:** Together AI
+- **Deployer:** Together AI
+- **Artifact Details:**
+
+| Type | Name |
+| --- | --- | 
+| Model | Llama-3.3-70B-Instruct-Turbo |
+
+## Other information
+
+- **Report Type:** Measurement
+- **Credits:** Harsh Raj
+- **Date Reported:** 2025-05-26
+- **Version:** 0.2
+- [AVID Entry](https://github.com/avidml/avid-db/tree/main/reports/2025/AVID-2025-R0014.json)
+

--- a/exampleSite/content/database/reports/2025/AVID-2025-R0015.md
+++ b/exampleSite/content/database/reports/2025/AVID-2025-R0015.md
@@ -1,0 +1,53 @@
+---
+title: AVID-2025-R0015
+layout: page
+url: /database/AVID-2025-R0015
+---
+
+## Description
+
+Evaluation of the LLM Llama-3.3-70B-Instruct-Turbo on the wmdp_cyber benchmark using Inspect Evals
+
+## Details
+
+WMDP is a dataset of 3,668 multiple-choice questions surrounding hazardous knowledge in biosecurity, cybersecurity, and chemical security. WMDP serves as both a proxy evaluation for hazardous knowledge in large language models (LLMs) and a benchmark for unlearning methods to remove such knowledge.
+
+We evaluated the LLM Llama-3.3-70B-Instruct-Turbo on this benchmark.
+
+## Metrics
+
+A simple accuracy is calculated over the datapoints.
+
+| Scorer | Metric | Value |
+| --- | --- | --- |
+| choice | accuracy | 0.59 |
+| choice | stderr | 0.01 |
+
+## References
+
+- [Inspect Evaluation Log for dataset: cais/wmdp](https://avidmvp.s3.amazonaws.com/2025-05-10T13-42-37+00-00_wmdp-cyber_KowS42BxM2ks2X9Ja5Enid.eval)
+
+## AVID Taxonomy Categorization
+
+- **Risk domains:** Performance
+- **SEP subcategories:** P0402: Physical Safety
+- **Lifecycle stages:** L05: Evaluation
+
+## Affected or Relevant Artifacts
+
+- **Developer:** Together AI
+- **Deployer:** Together AI
+- **Artifact Details:**
+
+| Type | Name |
+| --- | --- | 
+| Model | Llama-3.3-70B-Instruct-Turbo |
+
+## Other information
+
+- **Report Type:** Measurement
+- **Credits:** Harsh Raj
+- **Date Reported:** 2025-05-26
+- **Version:** 0.2
+- [AVID Entry](https://github.com/avidml/avid-db/tree/main/reports/2025/AVID-2025-R0015.json)
+

--- a/exampleSite/content/database/reports/2025/AVID-2025-R0016.md
+++ b/exampleSite/content/database/reports/2025/AVID-2025-R0016.md
@@ -1,0 +1,53 @@
+---
+title: AVID-2025-R0016
+layout: page
+url: /database/AVID-2025-R0016
+---
+
+## Description
+
+Evaluation of the LLM Llama-3.3-70B-Instruct-Turbo on the cyse2_interpreter_abuse benchmark using Inspect Evals
+
+## Details
+
+CyberSecEval2 is A Wide-Ranging Cybersecurity Evaluation Suite for Large Language Models’ risky capabilities in cybersecurity.
+
+We evaluated the LLM Llama-3.3-70B-Instruct-Turbo on this benchmark.
+
+## Metrics
+
+A simple average is calculated over the test cases, indicating the rate at which the model behavior could be classified as harmful (lower scores are better).
+
+| Scorer | Metric | Value |
+| --- | --- | --- |
+| model_graded_qa | accuracy | 0.31 |
+| model_graded_qa | stderr | 0.02 |
+
+## References
+
+- [Inspect Evaluation Log for dataset: interpreter](https://avidmvp.s3.amazonaws.com/2025-05-10T13-55-33+00-00_cyse2-interpreter-abuse_Djq84gfT6keJs3NDKPk8mH.eval)
+
+## AVID Taxonomy Categorization
+
+- **Risk domains:** Security
+- **SEP subcategories:** S0403: Adversarial Example
+- **Lifecycle stages:** L05: Evaluation
+
+## Affected or Relevant Artifacts
+
+- **Developer:** Together AI
+- **Deployer:** Together AI
+- **Artifact Details:**
+
+| Type | Name |
+| --- | --- | 
+| Model | Llama-3.3-70B-Instruct-Turbo |
+
+## Other information
+
+- **Report Type:** Measurement
+- **Credits:** Harsh Raj
+- **Date Reported:** 2025-05-26
+- **Version:** 0.2
+- [AVID Entry](https://github.com/avidml/avid-db/tree/main/reports/2025/AVID-2025-R0016.json)
+

--- a/exampleSite/content/database/reports/2025/AVID-2025-R0017.md
+++ b/exampleSite/content/database/reports/2025/AVID-2025-R0017.md
@@ -1,0 +1,53 @@
+---
+title: AVID-2025-R0017
+layout: page
+url: /database/AVID-2025-R0017
+---
+
+## Description
+
+Evaluation of the LLM Llama-3.3-70B-Instruct-Turbo on the cyse2_prompt_injection benchmark using Inspect Evals
+
+## Details
+
+CyberSecEval2 is A Wide-Ranging Cybersecurity Evaluation Suite for Large Language Models’ risky capabilities in cybersecurity.
+
+We evaluated the LLM Llama-3.3-70B-Instruct-Turbo on this benchmark.
+
+## Metrics
+
+A simple average is calculated over the test cases, indicating the rate at which the model behavior could be classified as harmful (lower scores are better).
+
+| Scorer | Metric | Value |
+| --- | --- | --- |
+| model_graded_qa | accuracy | 0.36 |
+| model_graded_qa | stderr | 0.03 |
+
+## References
+
+- [Inspect Evaluation Log for dataset: prompt_injection](https://avidmvp.s3.amazonaws.com/2025-05-10T14-26-28+00-00_cyse2-prompt-injection_PQaMdDY9wksef6dQVa63Cm.eval)
+
+## AVID Taxonomy Categorization
+
+- **Risk domains:** Security
+- **SEP subcategories:** S0403: Adversarial Example
+- **Lifecycle stages:** L05: Evaluation
+
+## Affected or Relevant Artifacts
+
+- **Developer:** Together AI
+- **Deployer:** Together AI
+- **Artifact Details:**
+
+| Type | Name |
+| --- | --- | 
+| Model | Llama-3.3-70B-Instruct-Turbo |
+
+## Other information
+
+- **Report Type:** Measurement
+- **Credits:** Harsh Raj
+- **Date Reported:** 2025-05-26
+- **Version:** 0.2
+- [AVID Entry](https://github.com/avidml/avid-db/tree/main/reports/2025/AVID-2025-R0017.json)
+

--- a/exampleSite/content/database/reports/2025/AVID-2025-R0021.md
+++ b/exampleSite/content/database/reports/2025/AVID-2025-R0021.md
@@ -1,0 +1,71 @@
+---
+title: AVID-2025-R0021
+layout: page
+url: /database/AVID-2025-R0021
+---
+
+## Description
+
+Evaluation of the LLM DeepSeek-R1 on the agentharm benchmark using Inspect Evals
+
+## Details
+
+The benchmark agentharm is implemented by Inspect Evals. More details are available [here](https://ukgovernmentbeis.github.io/inspect_evals/evals/safeguards/agentharm/).
+
+We evaluated the LLM DeepSeek-R1 on this benchmark.
+
+## Metrics
+
+Scoring details are available [here](https://ukgovernmentbeis.github.io/inspect_evals/evals/safeguards/agentharm/).
+
+| Scorer | Metric | Value |
+| --- | --- | --- |
+| combined_scorer | avg_score | 0.00 |
+| combined_scorer | avg_full_score | 0.00 |
+| combined_scorer | avg_refusals | 0.57 |
+| combined_scorer | avg_score_non_refusals | 0.00 |
+| combined_scorer | Disinformation_avg_scores | 0.00 |
+| combined_scorer | Harassment_avg_scores | 0.00 |
+| combined_scorer | Drugs_avg_scores | 0.02 |
+| combined_scorer | Fraud_avg_scores | 0.00 |
+| combined_scorer | Hate_avg_scores | 0.00 |
+| combined_scorer | Cybercrime_avg_scores | 0.00 |
+| combined_scorer | Sexual_avg_scores | 0.00 |
+| combined_scorer | Copyright_avg_scores | 0.00 |
+| combined_scorer | Disinformation_avg_refusals | 0.40 |
+| combined_scorer | Harassment_avg_refusals | 0.71 |
+| combined_scorer | Drugs_avg_refusals | 0.45 |
+| combined_scorer | Fraud_avg_refusals | 0.58 |
+| combined_scorer | Hate_avg_refusals | 0.75 |
+| combined_scorer | Cybercrime_avg_refusals | 0.65 |
+| combined_scorer | Sexual_avg_refusals | 0.92 |
+| combined_scorer | Copyright_avg_refusals | 0.08 |
+
+## References
+
+- [Inspect Evaluation Log for dataset: harmful_behaviors_test_public](https://avidmvp.s3.amazonaws.com/2025-05-12T13-25-41+00-00_agentharm_WXzbmYDaQHVwxZ9QbE772k.eval)
+
+## AVID Taxonomy Categorization
+
+- **Risk domains:** Performance
+- **SEP subcategories:** P0400: Safety
+- **Lifecycle stages:** L05: Evaluation
+
+## Affected or Relevant Artifacts
+
+- **Developer:** Together AI
+- **Deployer:** Together AI
+- **Artifact Details:**
+
+| Type | Name |
+| --- | --- | 
+| Model | DeepSeek-R1 |
+
+## Other information
+
+- **Report Type:** Measurement
+- **Credits:** Harsh Raj
+- **Date Reported:** 2025-05-26
+- **Version:** 0.2
+- [AVID Entry](https://github.com/avidml/avid-db/tree/main/reports/2025/AVID-2025-R0021.json)
+

--- a/exampleSite/content/database/reports/2025/AVID-2025-R0022.md
+++ b/exampleSite/content/database/reports/2025/AVID-2025-R0022.md
@@ -1,0 +1,53 @@
+---
+title: AVID-2025-R0022
+layout: page
+url: /database/AVID-2025-R0022
+---
+
+## Description
+
+Evaluation of the LLM DeepSeek-R1 on the wmdp_bio benchmark using Inspect Evals
+
+## Details
+
+WMDP is a dataset of 3,668 multiple-choice questions surrounding hazardous knowledge in biosecurity, cybersecurity, and chemical security. WMDP serves as both a proxy evaluation for hazardous knowledge in large language models (LLMs) and a benchmark for unlearning methods to remove such knowledge.
+
+We evaluated the LLM DeepSeek-R1 on this benchmark.
+
+## Metrics
+
+A simple accuracy is calculated over the datapoints.
+
+| Scorer | Metric | Value |
+| --- | --- | --- |
+| choice | accuracy | 0.75 |
+| choice | stderr | 0.01 |
+
+## References
+
+- [Inspect Evaluation Log for dataset: cais/wmdp](https://avidmvp.s3.amazonaws.com/2025-05-12T13-35-32+00-00_wmdp-bio_m35ZYfbfobYHiLpFXoKg94.eval)
+
+## AVID Taxonomy Categorization
+
+- **Risk domains:** Performance
+- **SEP subcategories:** P0402: Physical Safety
+- **Lifecycle stages:** L05: Evaluation
+
+## Affected or Relevant Artifacts
+
+- **Developer:** Together AI
+- **Deployer:** Together AI
+- **Artifact Details:**
+
+| Type | Name |
+| --- | --- | 
+| Model | DeepSeek-R1 |
+
+## Other information
+
+- **Report Type:** Measurement
+- **Credits:** Harsh Raj
+- **Date Reported:** 2025-05-26
+- **Version:** 0.2
+- [AVID Entry](https://github.com/avidml/avid-db/tree/main/reports/2025/AVID-2025-R0022.json)
+

--- a/exampleSite/content/database/reports/2025/AVID-2025-R0023.md
+++ b/exampleSite/content/database/reports/2025/AVID-2025-R0023.md
@@ -1,0 +1,53 @@
+---
+title: AVID-2025-R0023
+layout: page
+url: /database/AVID-2025-R0023
+---
+
+## Description
+
+Evaluation of the LLM DeepSeek-R1 on the wmdp_chem benchmark using Inspect Evals
+
+## Details
+
+WMDP is a dataset of 3,668 multiple-choice questions surrounding hazardous knowledge in biosecurity, cybersecurity, and chemical security. WMDP serves as both a proxy evaluation for hazardous knowledge in large language models (LLMs) and a benchmark for unlearning methods to remove such knowledge.
+
+We evaluated the LLM DeepSeek-R1 on this benchmark.
+
+## Metrics
+
+A simple accuracy is calculated over the datapoints.
+
+| Scorer | Metric | Value |
+| --- | --- | --- |
+| choice | accuracy | 0.61 |
+| choice | stderr | 0.02 |
+
+## References
+
+- [Inspect Evaluation Log for dataset: cais/wmdp](https://avidmvp.s3.amazonaws.com/2025-05-12T15-18-59+00-00_wmdp-chem_55hWZM59PuVeYd9btUQarj.eval)
+
+## AVID Taxonomy Categorization
+
+- **Risk domains:** Performance
+- **SEP subcategories:** P0402: Physical Safety
+- **Lifecycle stages:** L05: Evaluation
+
+## Affected or Relevant Artifacts
+
+- **Developer:** Together AI
+- **Deployer:** Together AI
+- **Artifact Details:**
+
+| Type | Name |
+| --- | --- | 
+| Model | DeepSeek-R1 |
+
+## Other information
+
+- **Report Type:** Measurement
+- **Credits:** Harsh Raj
+- **Date Reported:** 2025-05-26
+- **Version:** 0.2
+- [AVID Entry](https://github.com/avidml/avid-db/tree/main/reports/2025/AVID-2025-R0023.json)
+

--- a/exampleSite/content/database/reports/2025/AVID-2025-R0024.md
+++ b/exampleSite/content/database/reports/2025/AVID-2025-R0024.md
@@ -1,0 +1,53 @@
+---
+title: AVID-2025-R0024
+layout: page
+url: /database/AVID-2025-R0024
+---
+
+## Description
+
+Evaluation of the LLM DeepSeek-R1 on the wmdp_cyber benchmark using Inspect Evals
+
+## Details
+
+WMDP is a dataset of 3,668 multiple-choice questions surrounding hazardous knowledge in biosecurity, cybersecurity, and chemical security. WMDP serves as both a proxy evaluation for hazardous knowledge in large language models (LLMs) and a benchmark for unlearning methods to remove such knowledge.
+
+We evaluated the LLM DeepSeek-R1 on this benchmark.
+
+## Metrics
+
+A simple accuracy is calculated over the datapoints.
+
+| Scorer | Metric | Value |
+| --- | --- | --- |
+| choice | accuracy | 0.35 |
+| choice | stderr | 0.01 |
+
+## References
+
+- [Inspect Evaluation Log for dataset: cais/wmdp](https://avidmvp.s3.amazonaws.com/2025-05-12T17-35-22+00-00_wmdp-cyber_m6LLBaPAbys5MQSFuzd7YH.eval)
+
+## AVID Taxonomy Categorization
+
+- **Risk domains:** Performance
+- **SEP subcategories:** P0402: Physical Safety
+- **Lifecycle stages:** L05: Evaluation
+
+## Affected or Relevant Artifacts
+
+- **Developer:** Together AI
+- **Deployer:** Together AI
+- **Artifact Details:**
+
+| Type | Name |
+| --- | --- | 
+| Model | DeepSeek-R1 |
+
+## Other information
+
+- **Report Type:** Measurement
+- **Credits:** Harsh Raj
+- **Date Reported:** 2025-05-26
+- **Version:** 0.2
+- [AVID Entry](https://github.com/avidml/avid-db/tree/main/reports/2025/AVID-2025-R0024.json)
+

--- a/exampleSite/content/database/reports/2025/AVID-2025-R0025.md
+++ b/exampleSite/content/database/reports/2025/AVID-2025-R0025.md
@@ -1,0 +1,53 @@
+---
+title: AVID-2025-R0025
+layout: page
+url: /database/AVID-2025-R0025
+---
+
+## Description
+
+Evaluation of the LLM DeepSeek-R1 on the cyse2_interpreter_abuse benchmark using Inspect Evals
+
+## Details
+
+CyberSecEval2 is A Wide-Ranging Cybersecurity Evaluation Suite for Large Language Models’ risky capabilities in cybersecurity.
+
+We evaluated the LLM DeepSeek-R1 on this benchmark.
+
+## Metrics
+
+A simple average is calculated over the test cases, indicating the rate at which the model behavior could be classified as harmful (lower scores are better).
+
+| Scorer | Metric | Value |
+| --- | --- | --- |
+| model_graded_qa | accuracy | 0.51 |
+| model_graded_qa | stderr | 0.02 |
+
+## References
+
+- [Inspect Evaluation Log for dataset: interpreter](https://avidmvp.s3.amazonaws.com/2025-05-12T19-38-34+00-00_cyse2-interpreter-abuse_cPeC5zwjDwGdYtebgHqtSU.eval)
+
+## AVID Taxonomy Categorization
+
+- **Risk domains:** Security
+- **SEP subcategories:** S0403: Adversarial Example
+- **Lifecycle stages:** L05: Evaluation
+
+## Affected or Relevant Artifacts
+
+- **Developer:** Together AI
+- **Deployer:** Together AI
+- **Artifact Details:**
+
+| Type | Name |
+| --- | --- | 
+| Model | DeepSeek-R1 |
+
+## Other information
+
+- **Report Type:** Measurement
+- **Credits:** Harsh Raj
+- **Date Reported:** 2025-05-26
+- **Version:** 0.2
+- [AVID Entry](https://github.com/avidml/avid-db/tree/main/reports/2025/AVID-2025-R0025.json)
+

--- a/exampleSite/content/database/reports/2025/AVID-2025-R0030.md
+++ b/exampleSite/content/database/reports/2025/AVID-2025-R0030.md
@@ -1,0 +1,71 @@
+---
+title: AVID-2025-R0030
+layout: page
+url: /database/AVID-2025-R0030
+---
+
+## Description
+
+Evaluation of the LLM Mistral-Small-24B-Instruct-2501 on the agentharm benchmark using Inspect Evals
+
+## Details
+
+The benchmark agentharm is implemented by Inspect Evals. More details are available [here](https://ukgovernmentbeis.github.io/inspect_evals/evals/safeguards/agentharm/).
+
+We evaluated the LLM Mistral-Small-24B-Instruct-2501 on this benchmark.
+
+## Metrics
+
+Scoring details are available [here](https://ukgovernmentbeis.github.io/inspect_evals/evals/safeguards/agentharm/).
+
+| Scorer | Metric | Value |
+| --- | --- | --- |
+| combined_scorer | avg_score | 0.04 |
+| combined_scorer | avg_full_score | 0.02 |
+| combined_scorer | avg_refusals | 0.19 |
+| combined_scorer | avg_score_non_refusals | 0.05 |
+| combined_scorer | Disinformation_avg_scores | 0.08 |
+| combined_scorer | Harassment_avg_scores | 0.02 |
+| combined_scorer | Drugs_avg_scores | 0.16 |
+| combined_scorer | Fraud_avg_scores | 0.01 |
+| combined_scorer | Hate_avg_scores | 0.01 |
+| combined_scorer | Cybercrime_avg_scores | 0.00 |
+| combined_scorer | Sexual_avg_scores | 0.00 |
+| combined_scorer | Copyright_avg_scores | 0.05 |
+| combined_scorer | Disinformation_avg_refusals | 0.05 |
+| combined_scorer | Harassment_avg_refusals | 0.33 |
+| combined_scorer | Drugs_avg_refusals | 0.15 |
+| combined_scorer | Fraud_avg_refusals | 0.08 |
+| combined_scorer | Hate_avg_refusals | 0.10 |
+| combined_scorer | Cybercrime_avg_refusals | 0.35 |
+| combined_scorer | Sexual_avg_refusals | 0.42 |
+| combined_scorer | Copyright_avg_refusals | 0.00 |
+
+## References
+
+- [Inspect Evaluation Log for dataset: harmful_behaviors_test_public](https://avidmvp.s3.amazonaws.com/2025-05-13T17-00-46+00-00_agentharm_BQq6FwScSeeeJv2SHwygug.eval)
+
+## AVID Taxonomy Categorization
+
+- **Risk domains:** Performance
+- **SEP subcategories:** P0400: Safety
+- **Lifecycle stages:** L05: Evaluation
+
+## Affected or Relevant Artifacts
+
+- **Developer:** Together AI
+- **Deployer:** Together AI
+- **Artifact Details:**
+
+| Type | Name |
+| --- | --- | 
+| Model | Mistral-Small-24B-Instruct-2501 |
+
+## Other information
+
+- **Report Type:** Measurement
+- **Credits:** Harsh Raj
+- **Date Reported:** 2025-05-26
+- **Version:** 0.2
+- [AVID Entry](https://github.com/avidml/avid-db/tree/main/reports/2025/AVID-2025-R0030.json)
+

--- a/exampleSite/content/database/reports/2025/AVID-2025-R0031.md
+++ b/exampleSite/content/database/reports/2025/AVID-2025-R0031.md
@@ -1,0 +1,53 @@
+---
+title: AVID-2025-R0031
+layout: page
+url: /database/AVID-2025-R0031
+---
+
+## Description
+
+Evaluation of the LLM Mistral-Small-24B-Instruct-2501 on the wmdp_bio benchmark using Inspect Evals
+
+## Details
+
+WMDP is a dataset of 3,668 multiple-choice questions surrounding hazardous knowledge in biosecurity, cybersecurity, and chemical security. WMDP serves as both a proxy evaluation for hazardous knowledge in large language models (LLMs) and a benchmark for unlearning methods to remove such knowledge.
+
+We evaluated the LLM Mistral-Small-24B-Instruct-2501 on this benchmark.
+
+## Metrics
+
+A simple accuracy is calculated over the datapoints.
+
+| Scorer | Metric | Value |
+| --- | --- | --- |
+| choice | accuracy | 0.78 |
+| choice | stderr | 0.01 |
+
+## References
+
+- [Inspect Evaluation Log for dataset: cais/wmdp](https://avidmvp.s3.amazonaws.com/2025-05-15T01-07-59+00-00_wmdp-bio_M4m3AtSEkTLF7gxhNkf2YR.eval)
+
+## AVID Taxonomy Categorization
+
+- **Risk domains:** Performance
+- **SEP subcategories:** P0402: Physical Safety
+- **Lifecycle stages:** L05: Evaluation
+
+## Affected or Relevant Artifacts
+
+- **Developer:** Together AI
+- **Deployer:** Together AI
+- **Artifact Details:**
+
+| Type | Name |
+| --- | --- | 
+| Model | Mistral-Small-24B-Instruct-2501 |
+
+## Other information
+
+- **Report Type:** Measurement
+- **Credits:** Harsh Raj
+- **Date Reported:** 2025-05-26
+- **Version:** 0.2
+- [AVID Entry](https://github.com/avidml/avid-db/tree/main/reports/2025/AVID-2025-R0031.json)
+

--- a/exampleSite/content/database/reports/2025/AVID-2025-R0032.md
+++ b/exampleSite/content/database/reports/2025/AVID-2025-R0032.md
@@ -1,0 +1,53 @@
+---
+title: AVID-2025-R0032
+layout: page
+url: /database/AVID-2025-R0032
+---
+
+## Description
+
+Evaluation of the LLM Mistral-Small-24B-Instruct-2501 on the wmdp_chem benchmark using Inspect Evals
+
+## Details
+
+WMDP is a dataset of 3,668 multiple-choice questions surrounding hazardous knowledge in biosecurity, cybersecurity, and chemical security. WMDP serves as both a proxy evaluation for hazardous knowledge in large language models (LLMs) and a benchmark for unlearning methods to remove such knowledge.
+
+We evaluated the LLM Mistral-Small-24B-Instruct-2501 on this benchmark.
+
+## Metrics
+
+A simple accuracy is calculated over the datapoints.
+
+| Scorer | Metric | Value |
+| --- | --- | --- |
+| choice | accuracy | 0.59 |
+| choice | stderr | 0.02 |
+
+## References
+
+- [Inspect Evaluation Log for dataset: cais/wmdp](https://avidmvp.s3.amazonaws.com/2025-05-15T01-08-53+00-00_wmdp-chem_CmV7g8B8shW36cgdGL24tV.eval)
+
+## AVID Taxonomy Categorization
+
+- **Risk domains:** Performance
+- **SEP subcategories:** P0402: Physical Safety
+- **Lifecycle stages:** L05: Evaluation
+
+## Affected or Relevant Artifacts
+
+- **Developer:** Together AI
+- **Deployer:** Together AI
+- **Artifact Details:**
+
+| Type | Name |
+| --- | --- | 
+| Model | Mistral-Small-24B-Instruct-2501 |
+
+## Other information
+
+- **Report Type:** Measurement
+- **Credits:** Harsh Raj
+- **Date Reported:** 2025-05-26
+- **Version:** 0.2
+- [AVID Entry](https://github.com/avidml/avid-db/tree/main/reports/2025/AVID-2025-R0032.json)
+

--- a/exampleSite/content/database/reports/2025/AVID-2025-R0033.md
+++ b/exampleSite/content/database/reports/2025/AVID-2025-R0033.md
@@ -1,0 +1,53 @@
+---
+title: AVID-2025-R0033
+layout: page
+url: /database/AVID-2025-R0033
+---
+
+## Description
+
+Evaluation of the LLM Mistral-Small-24B-Instruct-2501 on the wmdp_cyber benchmark using Inspect Evals
+
+## Details
+
+WMDP is a dataset of 3,668 multiple-choice questions surrounding hazardous knowledge in biosecurity, cybersecurity, and chemical security. WMDP serves as both a proxy evaluation for hazardous knowledge in large language models (LLMs) and a benchmark for unlearning methods to remove such knowledge.
+
+We evaluated the LLM Mistral-Small-24B-Instruct-2501 on this benchmark.
+
+## Metrics
+
+A simple accuracy is calculated over the datapoints.
+
+| Scorer | Metric | Value |
+| --- | --- | --- |
+| choice | accuracy | 0.49 |
+| choice | stderr | 0.01 |
+
+## References
+
+- [Inspect Evaluation Log for dataset: cais/wmdp](https://avidmvp.s3.amazonaws.com/2025-05-15T01-09-14+00-00_wmdp-cyber_SotYrCuu9QQCeg3k7ohtSR.eval)
+
+## AVID Taxonomy Categorization
+
+- **Risk domains:** Performance
+- **SEP subcategories:** P0402: Physical Safety
+- **Lifecycle stages:** L05: Evaluation
+
+## Affected or Relevant Artifacts
+
+- **Developer:** Together AI
+- **Deployer:** Together AI
+- **Artifact Details:**
+
+| Type | Name |
+| --- | --- | 
+| Model | Mistral-Small-24B-Instruct-2501 |
+
+## Other information
+
+- **Report Type:** Measurement
+- **Credits:** Harsh Raj
+- **Date Reported:** 2025-05-26
+- **Version:** 0.2
+- [AVID Entry](https://github.com/avidml/avid-db/tree/main/reports/2025/AVID-2025-R0033.json)
+

--- a/exampleSite/content/database/reports/2025/AVID-2025-R0034.md
+++ b/exampleSite/content/database/reports/2025/AVID-2025-R0034.md
@@ -1,0 +1,53 @@
+---
+title: AVID-2025-R0034
+layout: page
+url: /database/AVID-2025-R0034
+---
+
+## Description
+
+Evaluation of the LLM Mistral-Small-24B-Instruct-2501 on the cyse2_interpreter_abuse benchmark using Inspect Evals
+
+## Details
+
+CyberSecEval2 is A Wide-Ranging Cybersecurity Evaluation Suite for Large Language Models’ risky capabilities in cybersecurity.
+
+We evaluated the LLM Mistral-Small-24B-Instruct-2501 on this benchmark.
+
+## Metrics
+
+A simple average is calculated over the test cases, indicating the rate at which the model behavior could be classified as harmful (lower scores are better).
+
+| Scorer | Metric | Value |
+| --- | --- | --- |
+| model_graded_qa | accuracy | 0.21 |
+| model_graded_qa | stderr | 0.01 |
+
+## References
+
+- [Inspect Evaluation Log for dataset: interpreter](https://avidmvp.s3.amazonaws.com/2025-05-15T01-17-08+00-00_cyse2-interpreter-abuse_cWQUzPHLr2pcSaTv8kLYWi.eval)
+
+## AVID Taxonomy Categorization
+
+- **Risk domains:** Security
+- **SEP subcategories:** S0403: Adversarial Example
+- **Lifecycle stages:** L05: Evaluation
+
+## Affected or Relevant Artifacts
+
+- **Developer:** Together AI
+- **Deployer:** Together AI
+- **Artifact Details:**
+
+| Type | Name |
+| --- | --- | 
+| Model | Mistral-Small-24B-Instruct-2501 |
+
+## Other information
+
+- **Report Type:** Measurement
+- **Credits:** Harsh Raj
+- **Date Reported:** 2025-05-26
+- **Version:** 0.2
+- [AVID Entry](https://github.com/avidml/avid-db/tree/main/reports/2025/AVID-2025-R0034.json)
+

--- a/exampleSite/content/database/reports/2025/AVID-2025-R0035.md
+++ b/exampleSite/content/database/reports/2025/AVID-2025-R0035.md
@@ -1,0 +1,53 @@
+---
+title: AVID-2025-R0035
+layout: page
+url: /database/AVID-2025-R0035
+---
+
+## Description
+
+Evaluation of the LLM Mistral-Small-24B-Instruct-2501 on the cyse2_prompt_injection benchmark using Inspect Evals
+
+## Details
+
+CyberSecEval2 is A Wide-Ranging Cybersecurity Evaluation Suite for Large Language Models’ risky capabilities in cybersecurity.
+
+We evaluated the LLM Mistral-Small-24B-Instruct-2501 on this benchmark.
+
+## Metrics
+
+A simple average is calculated over the test cases, indicating the rate at which the model behavior could be classified as harmful (lower scores are better).
+
+| Scorer | Metric | Value |
+| --- | --- | --- |
+| model_graded_qa | accuracy | 0.29 |
+| model_graded_qa | stderr | 0.02 |
+
+## References
+
+- [Inspect Evaluation Log for dataset: prompt_injection](https://avidmvp.s3.amazonaws.com/2025-05-15T01-48-12+00-00_cyse2-prompt-injection_A2q4wdvCxnN8d9dFegkoRX.eval)
+
+## AVID Taxonomy Categorization
+
+- **Risk domains:** Security
+- **SEP subcategories:** S0403: Adversarial Example
+- **Lifecycle stages:** L05: Evaluation
+
+## Affected or Relevant Artifacts
+
+- **Developer:** Together AI
+- **Deployer:** Together AI
+- **Artifact Details:**
+
+| Type | Name |
+| --- | --- | 
+| Model | Mistral-Small-24B-Instruct-2501 |
+
+## Other information
+
+- **Report Type:** Measurement
+- **Credits:** Harsh Raj
+- **Date Reported:** 2025-05-26
+- **Version:** 0.2
+- [AVID Entry](https://github.com/avidml/avid-db/tree/main/reports/2025/AVID-2025-R0035.json)
+

--- a/scripts/render.py
+++ b/scripts/render.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+def _get_value(container, *keys, default=""):
+    current = container
+    for key in keys:
+        if not isinstance(current, dict):
+            return default
+        current = current.get(key)
+    if current is None:
+        return default
+    return current
+
+
+def _as_csv(values):
+    if isinstance(values, list):
+        return ", ".join(str(value) for value in values if value is not None)
+    if values is None:
+        return ""
+    return str(values)
+
+
+def _extract_year(report_id: str, source_path: Path) -> str:
+    parts = report_id.split("-")
+    if len(parts) >= 2 and parts[1].isdigit() and len(parts[1]) == 4:
+        return parts[1]
+
+    for parent in source_path.parents:
+        if parent.name.isdigit() and len(parent.name) == 4:
+            return parent.name
+
+    return "unknown"
+
+
+def _metrics_row(metric):
+    if isinstance(metric, dict):
+        scorer = metric.get("scorer", "")
+        metric_name = metric.get("metrics", metric.get("metric", ""))
+        value = metric.get("value", "")
+        if isinstance(value, (int, float)):
+            value = f"{value:.2f}"
+        return str(scorer), str(metric_name), str(value)
+
+    if isinstance(metric, list):
+        return "", "", "; ".join(str(item) for item in metric)
+
+    return "", "", str(metric)
+
+
+def _split_measurement_details(details: str):
+    if not isinstance(details, str):
+        return "", ""
+
+    pattern = re.compile(r"(?im)^##\s+Measurement details\s*$")
+    match = pattern.search(details)
+    if not match:
+        return details.strip(), ""
+
+    main_details = details[:match.start()].strip()
+    measurement_details = details[match.end():].strip()
+    return main_details, measurement_details
+
+
+def render_report_markdown(report: dict, source_path: Path) -> str:
+    report_id = _get_value(
+        report,
+        "metadata",
+        "report_id",
+        default=source_path.stem,
+    )
+    year = _extract_year(report_id, source_path)
+
+    description = _get_value(
+        report,
+        "problemtype",
+        "description",
+        "value",
+    )
+    details = _get_value(report, "description", "value")
+    details, measurement_details = _split_measurement_details(details)
+    metrics = report.get("metrics") or []
+    references = report.get("references") or []
+
+    risk_domains = _as_csv(
+        _get_value(report, "impact", "avid", "risk_domain", default=[])
+    )
+    sep_subcategories = _as_csv(
+        _get_value(report, "impact", "avid", "sep_view", default=[])
+    )
+    lifecycle_stages = _as_csv(
+        _get_value(report, "impact", "avid", "lifecycle_view", default=[])
+    )
+
+    developer = _as_csv(_get_value(report, "affects", "developer", default=[]))
+    deployer = _as_csv(_get_value(report, "affects", "deployer", default=[]))
+    artifacts = _get_value(report, "affects", "artifacts", default=[])
+
+    report_type = _get_value(report, "problemtype", "type")
+    credits = _as_csv(
+        [
+            credit.get("value")
+            for credit in (report.get("credit") or [])
+            if isinstance(credit, dict)
+        ]
+    )
+    reported_date = _get_value(report, "reported_date")
+    version = _get_value(report, "data_version")
+
+    lines = [
+        "---",
+        f"title: {report_id}",
+        "layout: page",
+        f"url: /database/{report_id}",
+        "---",
+        "",
+        "## Description",
+        "",
+        description,
+        "",
+        "## Details",
+        "",
+        details,
+        "",
+    ]
+
+    if metrics or measurement_details:
+        lines.extend(
+            [
+                "## Metrics",
+                "",
+            ]
+        )
+
+        if measurement_details:
+            lines.append(measurement_details)
+            lines.append("")
+
+        if metrics:
+            lines.extend(
+                [
+                    "| Scorer | Metric | Value |",
+                    "| --- | --- | --- |",
+                ]
+            )
+
+            for metric in metrics:
+                scorer, metric_name, value = _metrics_row(metric)
+                lines.append(f"| {scorer} | {metric_name} | {value} |")
+
+        lines.append("")
+
+    lines.extend(
+        [
+            "## References",
+            "",
+        ]
+    )
+
+    for reference in references:
+        label = (
+            reference.get("label", "")
+            if isinstance(reference, dict)
+            else ""
+        )
+        url = reference.get("url", "") if isinstance(reference, dict) else ""
+        lines.append(f"- [{label}]({url})")
+
+    lines.extend(
+        [
+            "",
+            "## AVID Taxonomy Categorization",
+            "",
+            f"- **Risk domains:** {risk_domains}",
+            f"- **SEP subcategories:** {sep_subcategories}",
+            f"- **Lifecycle stages:** {lifecycle_stages}",
+            "",
+            "## Affected or Relevant Artifacts",
+            "",
+            f"- **Developer:** {developer}",
+            f"- **Deployer:** {deployer}",
+            "- **Artifact Details:**",
+            "",
+            "| Type | Name |",
+            "| --- | --- | ",
+        ]
+    )
+
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            continue
+        artifact_type = artifact.get("type", "")
+        artifact_name = artifact.get("name", "")
+        lines.append(f"| {artifact_type} | {artifact_name} |")
+
+    lines.extend(
+        [
+            "",
+            "## Other information",
+            "",
+            f"- **Report Type:** {report_type}",
+            f"- **Credits:** {credits}",
+            f"- **Date Reported:** {reported_date}",
+            f"- **Version:** {version}",
+            (
+                "- [AVID Entry](https://github.com/avidml/avid-db/tree/main/"
+                f"reports/{year}/{source_path.name})"
+            ),
+            "",
+            "",
+        ]
+    )
+
+    return "\n".join(lines)
+
+
+def default_output_path(source_path: Path, website_root: Path) -> Path:
+    year = source_path.parent.name if source_path.parent.name.isdigit() else ""
+    reports_root = (
+        website_root / "exampleSite" / "content" / "database" / "reports"
+    )
+    if year:
+        return reports_root / year / f"{source_path.stem}.md"
+    return reports_root / f"{source_path.stem}.md"
+
+
+def render_file(source_path: Path, output_path: Path):
+    with source_path.open("r", encoding="utf-8") as source_file:
+        report = json.load(source_file)
+
+    markdown = render_report_markdown(report, source_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(markdown, encoding="utf-8")
+    print(f"Rendered {source_path} -> {output_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Render AVID report JSON files into website markdown pages."
+        )
+    )
+    parser.add_argument(
+        "input",
+        type=Path,
+        help=(
+            "Path to a report JSON file or a directory containing report "
+            "JSON files."
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help=(
+            "Optional output file or directory. If omitted, writes to "
+            "exampleSite/content/database/reports/<year>/"
+        ),
+    )
+
+    args = parser.parse_args()
+
+    website_root = Path(__file__).resolve().parent.parent
+    input_path = args.input.resolve()
+
+    if not input_path.exists():
+        raise FileNotFoundError(f"Input path does not exist: {input_path}")
+
+    if input_path.is_file():
+        output_path = (
+            args.output.resolve()
+            if args.output
+            else default_output_path(input_path, website_root)
+        )
+        if args.output and args.output.exists() and args.output.is_dir():
+            output_path = output_path / f"{input_path.stem}.md"
+        render_file(input_path, output_path)
+        return
+
+    json_files = sorted(
+        path for path in input_path.glob("*.json") if path.is_file()
+    )
+    if not json_files:
+        raise FileNotFoundError(
+            f"No JSON files found in directory: {input_path}"
+        )
+
+    if args.output:
+        output_base = args.output.resolve()
+        if output_base.suffix.lower() == ".md":
+            raise ValueError(
+                "When rendering a directory, --output must be "
+                "a directory path."
+            )
+    else:
+        year = input_path.name if input_path.name.isdigit() else ""
+        output_base = (
+            website_root / "exampleSite" / "content" / "database" / "reports"
+        )
+        if year:
+            output_base = output_base / year
+
+    for json_file in json_files:
+        output_path = output_base / f"{json_file.stem}.md"
+        render_file(json_file, output_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Sync website content with the latest merged avid-db updates and refresh rendered 2025 report pages.

## What changed
- Updated the `avid-db` submodule pointer to latest `main` (includes merged Inspect Evals normalization updates).
- Re-rendered 2025 website markdown reports from current JSON inputs.
- Intentionally preserved existing rendered content for:
  - AVID-2025-R0001.md
  - AVID-2025-R0002.md

## Validation
- Submodule is synced to latest `main`.
- Rendered 2025 markdown files align with current JSON report set.
- Working tree is clean after regeneration and selective preservation.

## Notes
- Scope is data/content sync and rendered output refresh only.
- No frontend template or UX behavior changes.